### PR TITLE
Making CachingConfig.Policies lazy

### DIFF
--- a/ObjectCacheExtension/CachingConfig.cs
+++ b/ObjectCacheExtension/CachingConfig.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System;
 using System.Configuration;
 
 namespace ObjectCacheExtension
@@ -11,16 +8,21 @@ namespace ObjectCacheExtension
     /// </summary>
     public static class CachingConfig
     {
+        private static readonly Lazy<CachingConfigurationCollection> _policies = new Lazy<CachingConfigurationCollection>(GetPolicies);
+
+        private static CachingConfigurationCollection GetPolicies()
+        {
+            CachingConfigurationSection caching = ConfigurationManager.GetSection("caching") as CachingConfigurationSection;
+            if (caching == null || caching.Policies == null)
+            {
+                throw new Exception("caching/policies path not found in config");
+            }
+            return caching.Policies;
+        }
+
         public static CachingConfigurationCollection Policies
         {
-            get
-            {
-                CachingConfigurationSection caching = ConfigurationManager.GetSection("caching") as CachingConfigurationSection;
-                if (caching == null || caching.Policies == null)
-                    throw new Exception("Caching configuration was not found");
-
-                return caching.Policies;
-            }
+            get { return _policies.Value; }
         }
     }
 }


### PR DESCRIPTION
Every time you access CachingConfig.Policies you call ConfigurationManager.GetSection() which isn't cheap. Let's read it once and wrap the call into Lazy<T>.
