### PR TITLE
Allow CachingConfigurationCollection.Item[] to accept name of not existing element

### DIFF
--- a/ObjectCacheExtension.Testing/CachingConfigurationTests.cs
+++ b/ObjectCacheExtension.Testing/CachingConfigurationTests.cs
@@ -1,11 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Linq;
 using System.Runtime.Caching;
-using System.Text;
+
 using NUnit.Framework;
-using ObjectCacheExtension;
 
 namespace ObjectCacheExtension.Testing
 {
@@ -15,11 +11,10 @@ namespace ObjectCacheExtension.Testing
         public class Collection
         {
             [Test]
-            [ExpectedException(typeof(ArgumentException))]
-            public void ShouldThrowArgumentExceptionWhenPolicyNameNotDefined()
+            public void ShouldReturnDefaultWhenPolicyNameNotDefined()
             { 
                 var policy = CachingConfig.Policies["MyCachingPolicy"];
-                Assert.Fail("Expected ArgumentException");
+                Assert.AreEqual(policy, CachingConfig.Policies.Default);
             }
 
             [Test]

--- a/ObjectCacheExtension/CachingConfigurationCollection.cs
+++ b/ObjectCacheExtension/CachingConfigurationCollection.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Configuration;
 
 namespace ObjectCacheExtension
@@ -13,23 +12,27 @@ namespace ObjectCacheExtension
             Lifetime = 30
         };
 
+        private static PolicyConfigurationElement defaultElement;
+
         public PolicyConfigurationElement Default
         {
-            get
+            get { return defaultElement ?? (defaultElement = GetDefault()); }
+        }
+
+        private PolicyConfigurationElement GetDefault()
+        {
+            PolicyConfigurationElement first = null;
+            foreach (var k in BaseGetAllKeys())
             {
-                PolicyConfigurationElement first = null;
-                foreach (var k in BaseGetAllKeys())
-                {
-                    PolicyConfigurationElement p = (PolicyConfigurationElement)BaseGet(k);
-                    if (first == null)
-                        first = p;
+                PolicyConfigurationElement p = (PolicyConfigurationElement)BaseGet(k);
+                if (first == null)
+                    first = p;
 
-                    if (p != null && p.IsDefault)
-                        return p;
-                }
-
-                return first ?? defaultWhenNothingIsDefined;
+                if (p != null && p.IsDefault)
+                    return p;
             }
+
+            return first ?? defaultWhenNothingIsDefined;
         }
 
         protected override ConfigurationElement CreateNewElement()
@@ -51,6 +54,5 @@ namespace ObjectCacheExtension
                 return policy ?? Default;
             }
         }
-
     }    
 }


### PR DESCRIPTION
When no element by specified name found, instead of trowing an exception, return the default.

Avoid NullReferenceException in Default.get
