### PR TITLE
Do not try to cache null values

### DIFF
--- a/ObjectCacheExtension.Testing/ObjectCacheExtensionTests.cs
+++ b/ObjectCacheExtension.Testing/ObjectCacheExtensionTests.cs
@@ -85,6 +85,20 @@ namespace ObjectCacheExtension.Testing
                 var secondResult = _cache.AddOrGetExisting<TestData>("testData2", () => { throw new Exception("I shouldn't have been called"); }, "sixHours");
                 Assert.AreSame(firstResult, secondResult);
             }
+
+            [Test]
+            public void ShouldNotCacheWhenResultIsNull()
+            {
+                var key = "testNull";
+
+                var result = _cache.AddOrGetExisting<TestData>(key, () => null);
+
+                Assert.IsNull(result);
+
+                result = _cache.AddOrGetExisting<TestData>(key, () => TestDataFactory.GetData());
+
+                Assert.IsNotNull(result);
+            }
         }
     }
 }

--- a/ObjectCacheExtension/ObjectCacheExtensions.cs
+++ b/ObjectCacheExtension/ObjectCacheExtensions.cs
@@ -53,7 +53,10 @@ namespace ObjectCacheExtension
                     if (objVal == null)
                     {
                         objVal = fallbackFunction.Invoke();
-                        cacheProvider.Set(cacheKey, objVal, policy);
+
+                        // Do not cache nulls
+                        if (objVal != null)
+                            cacheProvider.Set(cacheKey, objVal, policy);
                     }
                 }
             }


### PR DESCRIPTION
Sometimes a fallback function's result would be null (e.g. if some external service returns null) and I don't want to cache the null. `MemoryCache` would normally throw an exception, which I would catch and interpret. However, this has a performance impact. I would rather return the null, but not set it in the cache.

Do you agree?